### PR TITLE
Updates for test/doc failures in "Generic Service in DataProvider"

### DIFF
--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
 
             // Register ITestExtensionService1
-            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService1>(new TestExtensionService1("Test ExtensionService 1",10, null));
+            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService1>(new TestExtensionService1("Test ExtensionService 1", 10, null));
 
             // Retrieve ITestExtensionService1
             Assert.IsNotNull(MixedRealityToolkit.Instance.GetService<IMixedRealityExtensionService>());
@@ -300,7 +300,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
 
             // Add test 2 services
             MixedRealityToolkit.Instance.RegisterService<ITestInputDataProvider>(new TestInputDataProvider(CoreServices.InputSystem, "Test07-01-2.1", 10, null));
-            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService2>(new TestExtensionService2("Test07-01-2.2",10, null));
+            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService2>(new TestExtensionService2("Test07-01-2.2", 10, null));
 
             // Enable all test services
             MixedRealityToolkit.Instance.EnableAllServicesByType(typeof(ITestService));
@@ -328,7 +328,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
 
             // Add test 2 services
             MixedRealityToolkit.Instance.RegisterService<ITestInputDataProvider>(new TestInputDataProvider(CoreServices.InputSystem, "Test07-01-2.1", 10, null));
-            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService2>(new TestExtensionService2("Test07-01-2.2",10, null));
+            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService2>(new TestExtensionService2("Test07-01-2.2", 10, null));
 
             // Enable all test services
             MixedRealityToolkit.Instance.EnableAllServicesByType(typeof(ITestService));
@@ -376,7 +376,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             // service1 priority = 20
             // service2 priority = 30
             CollectionAssert.AreEqual(
-                new List<IMixedRealityService>(){ service3, service1, service2 },
+                new List<IMixedRealityService>() { service3, service1, service2 },
                 MixedRealityServiceRegistry.GetAllServices());
         }
 
@@ -473,7 +473,7 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
             {
                 Scene scene = SceneManager.GetSceneAt(i);
                 SceneManager.SetActiveScene(scene);
-                MixedRealityToolkit newInstance = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();                
+                MixedRealityToolkit newInstance = new GameObject("MixedRealityToolkit").AddComponent<MixedRealityToolkit>();
             }
 
             MixedRealityToolkit[] instances = GameObject.FindObjectsOfType<MixedRealityToolkit>();

--- a/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
+++ b/Assets/MixedRealityToolkit.Tests/EditModeTests/Core/MixedRealityToolkitTests.cs
@@ -290,14 +290,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
         [Test]
         public void TestEnableServicesByType()
         {
-            TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
+            // Use the default profile, since we need an input system for this test.
+            TestUtilities.InitializeMixedRealityToolkitAndCreateScenes(true);
 
             // Add test 1 services
-            MixedRealityToolkit.Instance.RegisterService<ITestDataProvider1>(new TestDataProvider1(null, "Test07-01-1.1", 10));
-            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService1>(new TestExtensionService1("Test07-01-1.2",10, null));
+            TestExtensionService1 service1 = new TestExtensionService1("Test07-01-1.2", 10, null);
+            MixedRealityToolkit.Instance.RegisterService<ITestDataProvider1>(new TestDataProvider1(service1, "Test07-01-1.1", 10));
+            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService1>(service1);
 
             // Add test 2 services
-            MixedRealityToolkit.Instance.RegisterService<ITestInputDataProvider>(new TestInputDataProvider(null, "Test07-01-2.1", 10, null));
+            MixedRealityToolkit.Instance.RegisterService<ITestInputDataProvider>(new TestInputDataProvider(CoreServices.InputSystem, "Test07-01-2.1", 10, null));
             MixedRealityToolkit.Instance.RegisterService<ITestExtensionService2>(new TestExtensionService2("Test07-01-2.2",10, null));
 
             // Enable all test services
@@ -316,14 +318,16 @@ namespace Microsoft.MixedReality.Toolkit.Tests.Core
         [Test]
         public void TestDisableServicesByType()
         {
-            TestUtilities.InitializeMixedRealityToolkitAndCreateScenes();
+            // Use the default profile, since we need an input system for this test.
+            TestUtilities.InitializeMixedRealityToolkitAndCreateScenes(true);
 
             // Add test 1 services
-            MixedRealityToolkit.Instance.RegisterService<ITestDataProvider1>(new TestDataProvider1(null, "Test07-01-1.1", 10));
-            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService1>(new TestExtensionService1("Test07-01-1.2",10, null));
+            TestExtensionService1 service1 = new TestExtensionService1("Test07-01-1.2", 10, null);
+            MixedRealityToolkit.Instance.RegisterService<ITestDataProvider1>(new TestDataProvider1(service1, "Test07-01-1.1", 10));
+            MixedRealityToolkit.Instance.RegisterService<ITestExtensionService1>(service1);
 
             // Add test 2 services
-            MixedRealityToolkit.Instance.RegisterService<ITestInputDataProvider>(new TestInputDataProvider(null, "Test07-01-2.1", 10, null));
+            MixedRealityToolkit.Instance.RegisterService<ITestInputDataProvider>(new TestInputDataProvider(CoreServices.InputSystem, "Test07-01-2.1", 10, null));
             MixedRealityToolkit.Instance.RegisterService<ITestExtensionService2>(new TestExtensionService2("Test07-01-2.2",10, null));
 
             // Enable all test services

--- a/Assets/MixedRealityToolkit/Services/BaseDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseDataProvider.cs
@@ -81,6 +81,6 @@ namespace Microsoft.MixedReality.Toolkit
         /// <summary>
         /// The service instance to which this provider is providing data.
         /// </summary>
-        protected T Service { get; set; } = default;
+        protected T Service { get; set; } = default(T);
     }
 }

--- a/Assets/MixedRealityToolkit/Services/BaseDataProvider.cs
+++ b/Assets/MixedRealityToolkit/Services/BaseDataProvider.cs
@@ -5,13 +5,8 @@ using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit
 {
-    /// <summary>
-    /// The base data provider implements <see cref="IMixedRealityDataProvider"/> and provides default properties for all data providers.
-    /// </summary>
-    /// <remarks>
-    /// Empty, but reserved for future use, in case additional <see cref="IMixedRealityDataProvider"/> properties or methods are assigned.
-    /// </remarks>
-    public abstract class BaseDataProvider<T> : BaseService, IMixedRealityDataProvider where T : IMixedRealityService
+    [System.Obsolete("Add a <T> of type IMixedRealityService, which defines the service type this data provider is valid for.")]
+    public abstract class BaseDataProvider : BaseDataProvider<IMixedRealityService>
     {
         /// <summary>
         /// Constructor.
@@ -24,7 +19,7 @@ namespace Microsoft.MixedReality.Toolkit
         [System.Obsolete("This constructor is obsolete (registrar parameter is no longer required) and will be removed in a future version of the Microsoft Mixed Reality Toolkit.")]
         protected BaseDataProvider(
             IMixedRealityServiceRegistrar registrar,
-            T service,
+            IMixedRealityService service,
             string name = null,
             uint priority = DefaultPriority,
             BaseMixedRealityProfile profile = null) : this(service, name, priority, profile)
@@ -32,6 +27,27 @@ namespace Microsoft.MixedReality.Toolkit
             Registrar = registrar;
         }
 
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="service">The <see cref="IMixedRealityService"/> to which the provider is providing data.</param>
+        /// <param name="name">The friendly name of the data provider.</param>
+        /// <param name="priority">The registration priority of the data provider.</param>
+        /// <param name="profile">The configuration profile for the data provider.</param>
+        protected BaseDataProvider(
+            IMixedRealityService service,
+            string name = null,
+            uint priority = DefaultPriority,
+            BaseMixedRealityProfile profile = null) : base(service, name, priority, profile)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The base data provider implements <see cref="IMixedRealityDataProvider"/> and provides default properties for all data providers.
+    /// </summary>
+    public abstract class BaseDataProvider<T> : BaseService, IMixedRealityDataProvider where T : IMixedRealityService
+    {
         /// <summary>
         /// Constructor.
         /// </summary>

--- a/Documentation/CameraSystem/CreateSettingsProvider.md
+++ b/Documentation/CameraSystem/CreateSettingsProvider.md
@@ -89,7 +89,7 @@ attribute to the class. This step enables setting the default profile and platfo
 Once the class has been defined, the next step is to provide the implementation of the [`IMixedRealityDataProvider`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityDataProvider) interface.
 
 > [!NOTE]
-> The [`BaseDataProvider`](xref:Microsoft.MixedReality.Toolkit.BaseDataProvider) class, via the [`BaseService`](xref:Microsoft.MixedReality.Toolkit.BaseService) class, provides empty implementations for [`IMixedRealityDataProvider`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityDataProvider) methods. The details of these methods are generally data provider specific.
+> The [`BaseDataProvider`](xref:Microsoft.MixedReality.Toolkit.BaseDataProvider`1) class, via the [`BaseService`](xref:Microsoft.MixedReality.Toolkit.BaseService) class, provides empty implementations for [`IMixedRealityDataProvider`](xref:Microsoft.MixedReality.Toolkit.IMixedRealityDataProvider) methods. The details of these methods are generally data provider specific.
 
 The methods that should be implemented by the data provider are:
 


### PR DESCRIPTION
## Overview

This PR:

* updates some tests to properly pass their (now required) services.
* re-adds the non-generic BaseDataProvider class, marking it as obsolete, to prevent this being a breaking change. It now calls into the new class' constructor.
* changes `default` to `default(T)`, as I believe `default` fails the UWP build
* updates a link in the docs to the new generic class